### PR TITLE
add version number to manifest

### DIFF
--- a/custom_components/localtuya/manifest.json
+++ b/custom_components/localtuya/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "localtuya",
   "name": "Tuya Local",
+  "version": "1.0.0",
   "documentation": "https://github.com/mileperhour/localtuya-homeassistant/",
   "dependencies": [],
   "codeowners": ["@mileperhour"],


### PR DESCRIPTION
Version number in manifest ist mandatory since Home Assistant 2021.6.

Fixes error message:
No 'version' key in the manifest file for custom integration 'localtuya'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'localtuya'